### PR TITLE
Add send message integration test

### DIFF
--- a/tests/send_message_test.cpp
+++ b/tests/send_message_test.cpp
@@ -1,0 +1,20 @@
+#include "Wool.hpp"
+#include <iostream>
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: " << argv[0] << " <channel_id>\n";
+        return 1;
+    }
+    const Wool::Snowflake channel_id = std::stoull(argv[1]);
+    Wool::Message msg;
+    msg.content = "Test message from automated test";
+    try {
+        Wool::Message res = Wool::Message::CreateMessage(channel_id, msg);
+        std::cout << "Sent message ID: " << res.id << "\n";
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Error sending message: " << e.what() << "\n";
+        return 1;
+    }
+}


### PR DESCRIPTION
## Summary
- add a small integration test that posts to a Discord channel
- update the test to accept channel id as a command-line argument

## Testing
- `g++ -std=c++17 tests/send_message_test.cpp Wool.cpp -o tests/send_message_test -lcurl -I.`
- `./tests/send_message_test 697744063679430656` *(fails: `[json.exception.type_error.302] type must be number, but is string`)*

------
https://chatgpt.com/codex/tasks/task_e_684846815d84832b90a0410453f0cef2