### PR TITLE
Add build setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,15 @@ Simple C++ helpers for interacting with Discord's message REST API.
 
 ## Building
 
+Run `scripts/setup.sh` to install dependencies and build the example and test binaries. This will create `example` and `tests/send_message_test`.
+
 This library uses libcurl and nlohmann::json. On Ubuntu you can install them with:
 
 ```bash
 sudo apt-get install libcurl4-openssl-dev nlohmann-json3-dev
 ```
 
-Compile the example program using:
+You can also compile the example program manually using:
 
 ```bash
 g++ -std=c++17 example.cpp Wool.cpp -o example -lcurl

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -e
+
+# Install dependencies if missing
+packages=(libcurl4-openssl-dev nlohmann-json3-dev)
+missing=()
+for pkg in "${packages[@]}"; do
+    if ! dpkg -s "$pkg" >/dev/null 2>&1; then
+        missing+=("$pkg")
+    fi
+done
+
+if [ ${#missing[@]} -gt 0 ]; then
+    echo "Installing missing packages: ${missing[*]}"
+    sudo apt-get update
+    sudo apt-get install -y "${missing[@]}"
+fi
+
+# Build example program
+echo "Building example.cpp"
+g++ -std=c++17 -I. example.cpp Wool.cpp -o example -lcurl
+
+# Build test program
+echo "Building tests/send_message_test.cpp"
+g++ -std=c++17 -I. tests/send_message_test.cpp Wool.cpp -o tests/send_message_test -lcurl
+
+cat <<'USAGE'
+
+Build complete.
+
+Usage:
+  ./example <channel_id> "<message>"
+  ./tests/send_message_test <channel_id>
+
+Ensure the DISCORD_BOT_TOKEN environment variable is set before running these executables.
+USAGE
+


### PR DESCRIPTION
## Summary
- add `scripts/setup.sh` to install dependencies and compile binaries
- mention `scripts/setup.sh` in README and note produced outputs

## Testing
- `./scripts/setup.sh > /tmp/setup.log && tail -n 20 /tmp/setup.log`


------
https://chatgpt.com/codex/tasks/task_e_68484da66684832b858501c3f6c9a197