### PR TITLE
Fix JSON conversion for Snowflake type

### DIFF
--- a/Wool.cpp
+++ b/Wool.cpp
@@ -10,6 +10,15 @@
 #include <cstdlib>
 
 namespace Wool {
+
+void to_json(nlohmann::json& j, const Snowflake& s) {
+    j = s.value;
+}
+
+void from_json(const nlohmann::json& j, Snowflake& s) {
+    s.value = j.get<unsigned long long>();
+}
+
 namespace {
 
 // Global logger instance used for all library logging


### PR DESCRIPTION
## Summary
- implement `to_json` and `from_json` for `Snowflake`
- ensure library compiles with new `Snowflake` struct

## Testing
- `./scripts/setup.sh`
- `./build/tests/send_message_test 123` *(fails: Invalid message JSON: [json.exception.out_of_range.403] key 'id' not found)*

------
https://chatgpt.com/codex/tasks/task_e_684959fa66bc832bbb07471b8203da47